### PR TITLE
Feature/core util 모듈 구현

### DIFF
--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/Date+DateFormat.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/Date+DateFormat.swift
@@ -1,0 +1,26 @@
+//
+//  Date+DateFormat.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public extension Date {
+    func formatted(with dateFormat: DateFormat) -> String {
+        let formatter = DateFormatHelper.formatter(dateFormat: dateFormat.rawValue)
+        
+        return formatter.string(from: self)
+    }
+}
+
+public extension String {
+    /// String to Date
+    func toDate(with dateFormat: DateFormat) -> Date? {
+        let formatter = DateFormatHelper.formatter(dateFormat: dateFormat.rawValue)
+        
+        return formatter.date(from: self)
+    }
+}
+

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/Date+DateFormat.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/Date+DateFormat.swift
@@ -23,4 +23,3 @@ public extension String {
         return formatter.date(from: self)
     }
 }
-

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormat.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormat.swift
@@ -1,0 +1,72 @@
+//
+//  DateFormat.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public enum DateFormat: String {
+    /// 년.월.일
+    case yyyyMMdd = "yyyy.MM.dd"
+    
+    /// 년-월-일
+    case yyyyMMddDash = "yyyy-MM-dd"
+
+    /// 한국어 년월일 (yyyy년 MM월 dd일)
+    case yyyyMMddKorean = "yyyy년 MM월 dd일"
+
+    /// 한국어 년월일 (yyyy년 M월 d일)
+    case yyyyMdKorean = "yyyy년 M월 d일"
+
+    /// 한국어 월일 (MM월 dd일)
+    case MMddKorean = "MM월 dd일"
+    
+    /// 년.월
+    case yyyyMM = "yyyy.MM"
+
+    /// 월.일
+    case MMdd = "MM.dd"
+    
+    /// 월.일
+    case Mdd = "M.dd"
+    
+    /// 시
+    case HH = "HH"
+
+    /// 년.월.일 시:분:초
+    case dateTime = "yyyy.MM.dd HH:mm:ss"
+
+    /// 년.월.일 시:분
+    case yyyyMMddHHmm = "yyyy.MM.dd HH:mm"
+    
+    /// 년-월-일 시:분
+    case yyyyMMddHHmmDash = "yyyy-MM-dd HH:mm"
+
+    /// 년.월.일 오전/오후 시:분
+    case yyyyMMddahhmm = "yyyy.MM.dd a hh:mm"
+
+    /// 년.월.일 오전/오후 시(24):분
+    case yyyyMMddaHHmm = "yyyy.MM.dd a HH:mm"
+
+    /// 시:분:초
+    case HHmmss = "HH:mm:ss"
+
+    /// 시:분
+    case HHmm = "HH:mm"
+
+    /// 오전/오후 시:분
+    case ahhmm = "a hh:mm"
+
+    /// 축약 요일 (월, 화)
+    case ee = "EE"
+
+    /// 서버 날짜, 시간 (년-월-일 시:분:초)
+    case serverDateTime = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+    
+    case iso08601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    
+    /// 월-일 시:분
+    case MMddaHHmm = "MM.dd a HH:mm"
+}

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormat.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormat.swift
@@ -19,6 +19,12 @@ public enum DateFormat: String {
 
     /// 한국어 년월일 (yyyy년 M월 d일)
     case yyyyMdKorean = "yyyy년 M월 d일"
+    
+    /// 한국어 년월일 | 오전/오후 시분 (yyyy년 MM월 dd일 | 오후 HH시 mm분)
+    case yyyyMMddHHmmKorean = "yyyy년 MM월 dd일 | a HH시 mm분"
+    
+    /// 한국어 년월일 | 오전/오후 시 (yyyy년 MM월 dd일 | 오후 HH시)
+    case yyyyMMddHHKorean = "yyyy년 MM월 dd일 | a HH시"
 
     /// 한국어 월일 (MM월 dd일)
     case MMddKorean = "MM월 dd일"

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@preconcurrency
 public enum DateFormatHelper {
     private static var cachedFormatters: [String: DateFormatter] = [:]
     
@@ -14,7 +15,7 @@ public enum DateFormatHelper {
     // MARK: - Private Method
 
     /// DateFormatter 꺼내오기
-    static func formatter(
+    public static func formatter(
         dateFormat: String,
         locale: Locale = .init(identifier: "ko_KR")
     ) -> DateFormatter {

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
@@ -19,10 +19,10 @@ public enum DateFormatHelper {
         locale: Locale = .init(identifier: "ko_KR")
     ) -> DateFormatter {
         let key = dateFormat + locale.identifier
-        if let cachedFormatter = DateFormatManager.cachedFormatters[key] { return cachedFormatter }
+        if let cachedFormatter = DateFormatHelper.cachedFormatters[key] { return cachedFormatter }
 
         let formatter = makeFormatter(withDateFormat: dateFormat, locale: locale)
-        DateFormatManager.cachedFormatters[key] = formatter
+        DateFormatHelper.cachedFormatters[key] = formatter
         return formatter
     }
     

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
@@ -28,7 +28,10 @@ public enum DateFormatHelper {
     }
     
     /// DateFormatter 생성
-    private static func makeFormatter(withDateFormat dateFormat: String, locale: Locale) -> DateFormatter {
+    private static func makeFormatter(
+        withDateFormat dateFormat: String,
+        locale: Locale
+    ) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = dateFormat
         formatter.locale = locale

--- a/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
+++ b/Projects/Core/HGCommon/Sources/DateFormatHelper/DateFormatHelper.swift
@@ -1,0 +1,37 @@
+//
+//  DateFormatHelper.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public enum DateFormatHelper {
+    private static var cachedFormatters: [String: DateFormatter] = [:]
+    
+        
+    // MARK: - Private Method
+
+    /// DateFormatter 꺼내오기
+    static func formatter(
+        dateFormat: String,
+        locale: Locale = .init(identifier: "ko_KR")
+    ) -> DateFormatter {
+        let key = dateFormat + locale.identifier
+        if let cachedFormatter = DateFormatManager.cachedFormatters[key] { return cachedFormatter }
+
+        let formatter = makeFormatter(withDateFormat: dateFormat, locale: locale)
+        DateFormatManager.cachedFormatters[key] = formatter
+        return formatter
+    }
+    
+    /// DateFormatter 생성
+    private static func makeFormatter(withDateFormat dateFormat: String, locale: Locale) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = dateFormat
+        formatter.locale = locale
+        
+        return formatter
+    }
+}

--- a/Projects/Core/HGCommon/Sources/Extensions/Array+Extension.swift
+++ b/Projects/Core/HGCommon/Sources/Extensions/Array+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  Array+Extension.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public extension Array {
+    var isNotEmpty: Bool {
+        !isEmpty
+    }
+}
+
+public extension Collection where Element: Hashable {
+    /// 배열 중복 제거
+    var deDuplicated: [Self.Element] {
+        var dict: [Element: Bool] = [:]
+        return filter { dict.updateValue(true, forKey: $0) == nil }
+    }
+}

--- a/Projects/Core/HGCommon/Sources/Extensions/Bundle+Extension.swift
+++ b/Projects/Core/HGCommon/Sources/Extensions/Bundle+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Bundle+Extension.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public extension Bundle {
+    var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        
+        return version ?? "Unknown"
+    }
+}

--- a/Projects/Core/HGCommon/Sources/Extensions/Optional+Extension.swift
+++ b/Projects/Core/HGCommon/Sources/Extensions/Optional+Extension.swift
@@ -1,0 +1,13 @@
+//
+//  Optional+Extension.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public extension Optional {
+    var isNil: Bool { self == nil }
+    var isSome: Bool { self != nil }
+}

--- a/Projects/Core/HGCommon/Sources/Extensions/String+Extension.swift
+++ b/Projects/Core/HGCommon/Sources/Extensions/String+Extension.swift
@@ -1,0 +1,13 @@
+//
+//  String+Extension.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+public extension String {
+    var asInt: Int? { Int(self) }
+    var asDouble: Double? { Double(self) }
+}

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum KeychainError: Error {
+    case invalidData
     case itemNotFound
     case deleteKeychainError
     case updateKeychainError

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
@@ -1,0 +1,14 @@
+//
+//  KeychainError.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 6/6/25.
+//
+
+import Foundation
+
+public enum KeychainError: Error {
+    case itemNotFound
+    case deleteKeychainError
+    case updateKeychainError
+}

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainError.swift
@@ -8,8 +8,16 @@
 import Foundation
 
 public enum KeychainError: Error {
+    
+    /// 유효하지 않은 데이터
     case invalidData
+    
+    /// 키체인에 저장된 값을 찾을 수 없음
     case itemNotFound
+    
+    /// 키체인 삭제 에러
     case deleteKeychainError
+    
+    /// 키체인 업데이트 에러
     case updateKeychainError
 }

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainKey.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainKey.swift
@@ -1,0 +1,16 @@
+//
+//  KeychainKey.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 6/6/25.
+//
+
+import Foundation
+
+/**
+ 키체인으로 어떤 Key를 관리하고 있는지 추적•관리하기 위해서 사용합니다.
+ 키체인에 사용할 Key값을 여기에 추가해서 사용해주세요!
+ */
+public enum KeychainKey: String {
+    case deviceToken
+}

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
@@ -20,7 +20,10 @@ public actor KeychainManager: KeychainManagerable {
     
     /// 키체인 추가
     public func addKeychain(key: KeychainKey, value: String) async throws {
-        let data = value.data(using: String.Encoding.utf8)!
+        guard let data = value.data(using: String.Encoding.utf8) else {
+            throw KeychainError.invalidData
+        }
+        
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: serviceKey,
@@ -41,13 +44,25 @@ public actor KeychainManager: KeychainManagerable {
     
     /// 키체인 업데이트
     public func updateKeychain(key: KeychainKey, value: String) async throws {
-        do {
-            try await deleteKeychain(key: key)
-            try await addKeychain(key: key, value: value)
-            print("📣 Success in updating key: \(key.rawValue), value: \(value)") // TODO: Log로 변경
-        } catch {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.invalidData
+        }
+        
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceKey,
+            kSecAttrAccount: key.rawValue
+        ]
+        
+        let attributes: [CFString: Any] = [kSecValueData: data]
+        
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        
+        if status != errSecSuccess {
             throw KeychainError.updateKeychainError
         }
+        
+        print("📣 Success in updating key: \(key.rawValue), value: \(value)") // TODO: Log로 변경
     }
     
     /// 키체인 읽기

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
@@ -36,7 +36,7 @@ public actor KeychainManager: KeychainManagerable {
         if status == errSecSuccess {
             print("📣 Success in saving key: \(key.rawValue), value: \(value)") // TODO: Log로 변경
         } else if status == errSecDuplicateItem {
-            _ = try await updateKeychain(key: key, value: value)
+            try await updateKeychain(key: key, value: value)
         } else {
             throw KeychainError.itemNotFound
         }
@@ -85,20 +85,22 @@ public actor KeychainManager: KeychainManagerable {
         
         guard let existingItem = item as? [String: Any],
               let data = existingItem[kSecValueData as String] as? Data,
-              let keyChain = String(data: data, encoding: .utf8) else {
+              let keychain = String(data: data, encoding: .utf8) else {
             throw KeychainError.itemNotFound
         }
         
-        print("📣 Success in reading key: \(key.rawValue), value: \(keyChain)") // TODO: Log로 변경
+        print("📣 Success in reading key: \(key.rawValue), value: \(keychain)") // TODO: Log로 변경
         
-        return keyChain
+        return keychain
     }
     
     /// 키체인 삭제
     public func deleteKeychain(key: KeychainKey) async throws {
-        let deleteQuery: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
-                                      kSecAttrService: serviceKey,
-                                      kSecAttrAccount: key.rawValue]
+        let deleteQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceKey,
+            kSecAttrAccount: key.rawValue
+        ]
         let status = SecItemDelete(deleteQuery as CFDictionary)
         if status != errSecSuccess {
             throw KeychainError.deleteKeychainError

--- a/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
+++ b/Projects/Core/HGCommon/Sources/KeychainManager/KeychainManager.swift
@@ -1,0 +1,93 @@
+//
+//  KeychainManager.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 6/6/25.
+//
+
+import Foundation
+
+public protocol KeychainManagerable {
+    func addKeychain(key: KeychainKey, value: String) async throws
+    func updateKeychain(key: KeychainKey, value: String) async throws
+    func deleteKeychain(key: KeychainKey) async throws
+    func readKeychain(key: KeychainKey) async throws -> String
+}
+
+public actor KeychainManager: KeychainManagerable {
+    
+    private let serviceKey = Bundle.main.bundleIdentifier ?? "HGDGDS.HGCommon"
+    
+    /// 키체인 추가
+    public func addKeychain(key: KeychainKey, value: String) async throws {
+        let data = value.data(using: String.Encoding.utf8)!
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceKey,
+            kSecAttrAccount: key.rawValue,
+            kSecValueData: data
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        
+        if status == errSecSuccess {
+            print("📣 Success in saving key: \(key.rawValue), value: \(value)") // TODO: Log로 변경
+        } else if status == errSecDuplicateItem {
+            _ = try await updateKeychain(key: key, value: value)
+        } else {
+            throw KeychainError.itemNotFound
+        }
+    }
+    
+    /// 키체인 업데이트
+    public func updateKeychain(key: KeychainKey, value: String) async throws {
+        do {
+            try await deleteKeychain(key: key)
+            try await addKeychain(key: key, value: value)
+            print("📣 Success in updating key: \(key.rawValue), value: \(value)") // TODO: Log로 변경
+        } catch {
+            throw KeychainError.updateKeychainError
+        }
+    }
+    
+    /// 키체인 읽기
+    public func readKeychain(key: KeychainKey) async throws -> String {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceKey,
+            kSecAttrAccount: key.rawValue,
+            kSecReturnAttributes: true,
+            kSecReturnData: true,
+            kSecMatchLimit : kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        
+        if SecItemCopyMatching(query as CFDictionary, &item) != errSecSuccess {
+            print("📣 Fail in reading key: \(key.rawValue)") // TODO: Log로 변경
+        
+            throw KeychainError.itemNotFound
+        }
+        
+        guard let existingItem = item as? [String: Any],
+              let data = existingItem[kSecValueData as String] as? Data,
+              let keyChain = String(data: data, encoding: .utf8) else {
+            throw KeychainError.itemNotFound
+        }
+        
+        print("📣 Success in reading key: \(key.rawValue), value: \(keyChain)") // TODO: Log로 변경
+        
+        return keyChain
+    }
+    
+    /// 키체인 삭제
+    public func deleteKeychain(key: KeychainKey) async throws {
+        let deleteQuery: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
+                                      kSecAttrService: serviceKey,
+                                      kSecAttrAccount: key.rawValue]
+        let status = SecItemDelete(deleteQuery as CFDictionary)
+        if status != errSecSuccess {
+            throw KeychainError.deleteKeychainError
+        }
+        print("📣 Success in deleting key: \(key.rawValue)") // TODO: Log로 변경
+    }
+}

--- a/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
+++ b/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
@@ -1,0 +1,24 @@
+//
+//  Reducerable.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 5/26/25.
+//
+
+import Foundation
+
+@dynamicMemberLookup
+public protocol Reducerable {
+    associatedtype State
+    associatedtype Action
+    
+    var state: State { get }
+    
+    func reduce(action: Action)
+}
+
+public extension Reducerable {
+    subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
+           self.state[keyPath: keyPath]
+       }
+}

--- a/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
+++ b/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
@@ -14,7 +14,7 @@ public protocol Reducerable {
     
     var state: State { get }
     
-    func reduce(action: Action)
+    func reduce(_ action: Action)
 }
 
 public extension Reducerable {

--- a/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
+++ b/Projects/Core/HGCommon/Sources/Reducerable/Reducerable.swift
@@ -19,6 +19,6 @@ public protocol Reducerable {
 
 public extension Reducerable {
     subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
-           self.state[keyPath: keyPath]
-       }
+        self.state[keyPath: keyPath]
+    }
 }

--- a/Projects/Core/HGCommon/Sources/UserDefaults/HGUserDefault.swift
+++ b/Projects/Core/HGCommon/Sources/UserDefaults/HGUserDefault.swift
@@ -6,23 +6,22 @@
 //
 
 import Foundation
-import Swinject
 
 /**
  UserDefaultsProtocol 주입 필수 
  */
 @propertyWrapper
-struct HGUserDefault<T> {
+public struct HGUserDefault<T> {
     let key: String
     let defaultValue: T
     @Dependency var userDefaults: UserDefaultsProtocol
     
-    init(key: String, defaultValue: T) {
+    public init(key: String, defaultValue: T) {
         self.key = key
         self.defaultValue = defaultValue
     }
     
-    var wrappedValue: T {
+    public var wrappedValue: T {
         get {
             return userDefaults.object(forKey: key) as? T ?? defaultValue
         }

--- a/Projects/Core/HGCommon/Sources/UserDefaults/HGUserDefault.swift
+++ b/Projects/Core/HGCommon/Sources/UserDefaults/HGUserDefault.swift
@@ -1,0 +1,33 @@
+//
+//  HGUserDefault.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 6/6/25.
+//
+
+import Foundation
+import Swinject
+
+/**
+ UserDefaultsProtocol 주입 필수 
+ */
+@propertyWrapper
+struct HGUserDefault<T> {
+    let key: String
+    let defaultValue: T
+    @Dependency var userDefaults: UserDefaultsProtocol
+    
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    var wrappedValue: T {
+        get {
+            return userDefaults.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            userDefaults.set(newValue, forKey: key)
+        }
+    }
+}

--- a/Projects/Core/HGCommon/Sources/UserDefaults/UserDefaultsProtocol.swift
+++ b/Projects/Core/HGCommon/Sources/UserDefaults/UserDefaultsProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  UserDefaultsProtocol.swift
+//  HGCommon
+//
+//  Created by iOS신상우 on 6/6/25.
+//
+
+import Foundation
+
+protocol UserDefaultsProtocol {
+    func object(forKey defaultName: String) -> Any?
+    func set(_ value: Any?, forKey defaultName: String)
+    func removeObject(forKey defaultName: String)
+    func data(forKey defaultName: String) -> Data?
+}
+
+extension UserDefaults: UserDefaultsProtocol { }


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #13 
- #16 
- #17 

##  📝 작업 내용
### 1️⃣ MVI 아키텍처에 맞춰 프로토콜 정의했습니다.
#16 에서 의논한 결과대로 가장 간단한 구조로 결정했습니다.
```swift
@dynamicMemberLookup
public protocol Reducerable {
    associatedtype State
    associatedtype Action
    
    var state: State { get }
    
    func reduce(_ action: Action)
}

public extension Reducerable {
    subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
           self.state[keyPath: keyPath]
       }
}
```

실제 사용 예
```swift
@Observable // ✅ 붙이는거 필수! -> 추후 템플릿으로 만들게요
final class ContentViewModel: Reducerable {
    
    var state: State = .init()
    
    struct State {
        var count: Int = 0
    }
    
    enum Action {
        case increaseCount
        case decreaseCount
        case fetchRandomNumber
    }
    
    func reduce(_ action: Action) {
        switch action {
        case .increaseCount:
            state.count += 1
            
        case .decreaseCount:
            state.count -= 1
            
        case .fetchRandomNumber:
            Task {
                do {
                    state.count = try await fetchRandomNumber()
                } catch {
                    print("오류.")
                }
            }
        }
    }
}

// MARK: - Private Methods
private extension ContentViewModel {
    func fetchRandomNumber() async throws -> Int {
        try await Task.sleep(for: .seconds(1))
        return Int.random(in: 0..<100)
    }
}
```


> 🚨 @Observable 붙이는거 까먹으시면 안됩니둥 🚨

<br>

### 2️⃣ DateForamtHelper를 만들었습니다. (DateFormatter생성 오버헤드가 커서 캐싱하기 위함)
현재 만들어둔 DateFormat은
```swift
public enum DateFormat: String {
    /// 년.월.일
    case yyyyMMdd = "yyyy.MM.dd"
    
    /// 년-월-일
    case yyyyMMddDash = "yyyy-MM-dd"

    /// 한국어 년월일 (yyyy년 MM월 dd일)
    case yyyyMMddKorean = "yyyy년 MM월 dd일"

    /// 한국어 년월일 (yyyy년 M월 d일)
    case yyyyMdKorean = "yyyy년 M월 d일"

    /// 한국어 월일 (MM월 dd일)
    case MMddKorean = "MM월 dd일"
    
    /// 년.월
    case yyyyMM = "yyyy.MM"

    /// 월.일
    case MMdd = "MM.dd"
    
    /// 월.일
    case Mdd = "M.dd"
    
    /// 시
    case HH = "HH"

    /// 년.월.일 시:분:초
    case dateTime = "yyyy.MM.dd HH:mm:ss"

    /// 년.월.일 시:분
    case yyyyMMddHHmm = "yyyy.MM.dd HH:mm"
    
    /// 년-월-일 시:분
    case yyyyMMddHHmmDash = "yyyy-MM-dd HH:mm"

    /// 년.월.일 오전/오후 시:분
    case yyyyMMddahhmm = "yyyy.MM.dd a hh:mm"

    /// 년.월.일 오전/오후 시(24):분
    case yyyyMMddaHHmm = "yyyy.MM.dd a HH:mm"

    /// 시:분:초
    case HHmmss = "HH:mm:ss"

    /// 시:분
    case HHmm = "HH:mm"

    /// 오전/오후 시:분
    case ahhmm = "a hh:mm"

    /// 축약 요일 (월, 화)
    case ee = "EE"

    /// 서버 날짜, 시간 (년-월-일 시:분:초)
    case serverDateTime = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
    
    case iso08601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
    
    /// 월-일 시:분
    case MMddaHHmm = "MM.dd a HH:mm"
}
```
다음과 같으며 추가적인 포맷이 필요하다면 여기서 추가하시면 됩니다. 

사용방법은 다음과 같이 Date와 String타입을 확장하여 선언해두었으며 사용 예시는 다음과 같습니다.
```swift
public extension Date {
    func formatted(with dateFormat: DateFormat) -> String {
        let formatter = DateFormatHelper.formatter(dateFormat: dateFormat.rawValue)
        
        return formatter.string(from: self)
    }
}

public extension String {
    /// String to Date
    func toDate(with dateFormat: DateFormat) -> Date? {
        let formatter = DateFormatHelper.formatter(dateFormat: dateFormat.rawValue)
        
        return formatter.date(from: self)
    }
}

✅ 사용 예시
Date.now.formatted(with: .MMdd) // Date -> String
```

<br>

### 3️⃣ KeychainManager 구현했습니다. (실제 구현체는 actor타입 for 동시성)

```swift
// KeychainManager Interface
public protocol KeychainManagerable {
    func addKeychain(key: KeychainKey, value: String) async throws
    func updateKeychain(key: KeychainKey, value: String) async throws
    func deleteKeychain(key: KeychainKey) async throws
    func readKeychain(key: KeychainKey) async throws -> String
}
```

Keychain으로 관리할 key들 아래 타입에 추가해서 관리해주세요. 
```swift 
/**
 키체인으로 어떤 Key를 관리하고 있는지 추적•관리하기 위해서 사용합니다.
 키체인에 사용할 Key값을 여기에 추가해서 사용해주세요!
 */
public enum KeychainKey: String {
    case deviceToken
}
```
<br>

### 4️⃣ UserDefaults PropertyWrapper를 구현했습니다. 
🚨사용전 UserDefaultsProtocol타입으로 DI 필수 🚨
```swift
protocol UserDefaultsProtocol {
    func object(forKey defaultName: String) -> Any?
    func set(_ value: Any?, forKey defaultName: String)
    func removeObject(forKey defaultName: String)
    func data(forKey defaultName: String) -> Data?
}

extension UserDefaults: UserDefaultsProtocol { }

/**
 UserDefaultsProtocol 주입 필수 
 */
@propertyWrapper
struct HGUserDefault<T> {
    let key: String
    let defaultValue: T
    @Dependency var userDefaults: UserDefaultsProtocol
    
    init(key: String, defaultValue: T) {
        self.key = key
        self.defaultValue = defaultValue
    }
    
    var wrappedValue: T {
        get {
            return userDefaults.object(forKey: key) as? T ?? defaultValue
        }
        set {
            userDefaults.set(newValue, forKey: key)
        }
    }
}

```

<!--
## 📸 작업 스크린샷 (Optional)
- 참고하기 좋은 이미지가 있다면 첨부해주세요
- ex) 작업하는 Figma 화면, 에러로그 등

<img src="https://github.com/namsoo5.png" width="300" height="400"/>

|제목1|제목2|
|:---:|:---:|
|이미지1|이미지2|
-->
  

## 📣 그 외 알릴 내용
해결하지 못해 도움이 필요한 점, 리뷰에 참고하면 좋을점 등을 알려주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Swinject 기반 의존성 주입 컨테이너(DIContainer) 및 DI 설정 유틸리티 추가
  - Keychain 데이터 관리 기능(추가, 수정, 삭제, 조회) 및 관련 에러/키 정의
  - UserDefaults 프로토콜 및 타입 안전 프로퍼티 래퍼(HGUserDefault) 도입
  - Date, String, Array, Optional, Bundle 등 다양한 편의 확장 기능 추가
  - Info.plist 기본 설정(defaultPlist) 및 확장 지원
  - 앱 실행 초기화 및 의존성 구성 자동화(AppDelegate, UIApplicationDelegateAdaptor, DependencyConfiguration)
  - Reducerable 프로토콜 추가로 상태 관리 및 액션 처리 구조화

- **기타**
  - 외부 라이브러리 Swinject 및 기타 패키지 의존성 추가 및 버전 고정
  - 프로젝트 설정 및 Info.plist 구성 개선
  - Tuist 설정 간소화 및 패키지 관리 파일(Package.resolved) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->