### PR TITLE
NavigationBar 컴포넌트 구현

### DIFF
--- a/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarLeftButtonType.swift
+++ b/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarLeftButtonType.swift
@@ -1,0 +1,11 @@
+//
+//  HGNavigationBarLeftButtonType.swift
+//  HGDesignSystem
+//
+//  Created by Enes on 6/22/25.
+//
+
+public enum HGNavigationBarLeftButtonType {
+    case back
+    case close
+}

--- a/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarView.swift
+++ b/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarView.swift
@@ -1,0 +1,66 @@
+//
+//  HGNavigationBarView.swift
+//  HGDesignSystem
+//
+//  Created by Enes on 6/22/25.
+//
+
+import SwiftUI
+
+struct HGNavigationBarView<L: View, R: View>: View {
+    let title: String
+    @ViewBuilder let leftButtonView: L?
+    @ViewBuilder let rightButtonView: R?
+    private var titlePadding: CGFloat {
+        let padding: CGFloat = 16
+        let iconWidth: CGFloat = 24
+        return iconWidth + padding * 2
+    }
+    private let navigationBarHeight: CGFloat = 56
+    
+    init(
+        title: String = "",
+        @ViewBuilder leftButtonView: () -> L = { EmptyView() },
+        @ViewBuilder rightButtonView: () -> R = { EmptyView() }
+    ) {
+        self.title = title
+        self.leftButtonView = leftButtonView()
+        self.rightButtonView = rightButtonView()
+    }
+    
+    var body: some View {
+        ZStack {
+            Text(title)
+                .lineLimit(1)
+                .setTypo(.body_16_bold)
+                .foregroundStyle(.gray100Black)
+                .padding(.horizontal, titlePadding)
+            HStack {
+                leftButtonView
+                Spacer()
+                rightButtonView
+            }
+        }
+        .frame(height: navigationBarHeight)
+        .padding(.horizontal, 16)
+    }
+}
+
+#Preview {
+    VStack {
+        HGNavigationBarView(title: "타이틀 입니다 어디까지 늘어나나")
+        HGNavigationBarView(
+            title: "타이틀 입니다 어디까지 늘어나나가나다라마바사아",
+            leftButtonView: { Text("왼쪽") },
+            rightButtonView: { Text("오른쪽") }
+        )
+        HGNavigationBarView(
+            title: "타이틀 입니다 어디까지 늘어나나가나",
+            rightButtonView: { Text("오른쪽") }
+        )
+        HGNavigationBarView(
+            title: "타이틀 입니다 어디까지 ",
+            leftButtonView: { HGIcons.close.image }
+        )
+    }
+}

--- a/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarViewModifier.swift
+++ b/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarViewModifier.swift
@@ -1,0 +1,72 @@
+//
+//  HGNavigationBarViewModifier.swift
+//  HGDesignSystem
+//
+//  Created by Enes on 6/22/25.
+//
+
+import SwiftUI
+
+struct HGNavigationBarViewModifier<R: View>: ViewModifier {
+    @Environment(\.dismiss) var dismiss
+    let title: String
+    let leftButtonType: HGNavigationBarLeftButtonType
+    let leftButtonAction: (() -> Void)?
+    @ViewBuilder let rightButtonView: R?
+    
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            HGNavigationBarView(
+                title: title,
+                leftButtonView: { leftButton },
+                rightButtonView: { rightButtonView }
+            )
+            content
+                .fillMaxSize()
+        }
+    }
+    
+    private var leftButton: some View {
+        Button {
+            if leftButtonAction != nil {
+                leftButtonAction?()
+            } else {
+                dismiss()
+            }
+        } label: {
+            leftButtonImage
+                .foregroundStyle(.gray90)
+        }
+    }
+    
+    private var leftButtonImage: some View {
+        (leftButtonType == .back ? HGIcons.arrowLeft.image : HGIcons.close.image)
+            .resizable()
+            .frame(24)
+    }
+}
+
+public extension View {
+    func applyNavigationBar(
+        title: String,
+        leftButtonType type: HGNavigationBarLeftButtonType = .back,
+        leftAction: (() -> Void)? = nil,
+        @ViewBuilder rightButtonView: () -> some View = { EmptyView() }
+    ) -> some View {
+        self.modifier(
+            HGNavigationBarViewModifier(
+                title: title,
+                leftButtonType: type,
+                leftButtonAction: leftAction,
+                rightButtonView: rightButtonView
+            )
+        )
+    }
+}
+
+#Preview {
+    ZStack {
+        Text("화면")
+    }
+    .applyNavigationBar(title: "타이틀")
+}

--- a/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarViewModifier.swift
+++ b/Projects/UI/HGDesignSystem/Sources/NavigationBar/HGNavigationBarViewModifier.swift
@@ -23,6 +23,7 @@ struct HGNavigationBarViewModifier<R: View>: ViewModifier {
             )
             content
                 .fillMaxSize()
+                .toolbarVisibility(.hidden, for: .navigationBar)
         }
     }
     


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #41 


##  📝 작업 내용

> HGNavigationBarView

- 네비게이션바 구현체로 외부에서 사용할일 없습니다

> HGNavigationBarViewModifier
``` swift 
func applyNavigationBar(
    title: String,
    leftButtonType type: HGNavigationBarLeftButtonType = .back,
    leftAction: (() -> Void)? = nil,
    @ViewBuilder rightButtonView: () -> some View = { EmptyView() }
) -> some View 
```
  - 왼쪽버튼만 color들어가있고 오른쪽버튼은 외부에서 모든 설정해줘야합니다
  - leftAction으로 기본적으로 dismiss로직 들어가있고 커스텀 액션필요시만 넣으면됩니다
  - rightButton은 외부에서 주입받도록 설계했습니다
    - 아이콘형태도있고 텍스트형태도있어서 주입식으로 구현
  

  - 적용시 viewmodifier를 이용합니다

```swift
ZStack {
        Text("화면")
    }
    .applyNavigationBar(title: "타이틀")
```


## 📸 작업 스크린샷 (Optional)

<img width="646" alt="image" src="https://github.com/user-attachments/assets/e66361bd-ddcc-49ff-8fc7-bd30227de6c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 커스텀 타이틀과 좌/우 버튼을 지원하는 새로운 네비게이션 바 컴포넌트가 추가되었습니다.
    - "뒤로가기"와 "닫기" 타입을 구분하는 네비게이션 바 좌측 버튼 타입이 도입되었습니다.
    - SwiftUI 뷰에 손쉽게 네비게이션 바를 적용할 수 있는 뷰 수정자 및 확장 메서드가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->