### PR TITLE
photo picker 구현

### DIFF
--- a/Projects/UI/HGDesignSystem/Sources/Color/HGGradient.swift
+++ b/Projects/UI/HGDesignSystem/Sources/Color/HGGradient.swift
@@ -183,10 +183,10 @@ public enum HGGradient {
         endPoint: .bottom
     )
     
-    /// - warning: 디자인 시스템상에서 Opacity 0.3이 적용돼있지만
+    /// - warning: 디자인 시스템상에서 Opacity 0.3, 0.6이 적용돼있지만
     /// View로 사용해야해서 적용되지않은 상태입니다.
     /// 직접 적용해줘야합니다
-    public static let stroke30: LinearGradient = LinearGradient(
+    public static let strokeGradient: LinearGradient = .init(
         stops: [
             .init(color: .init(hex: "FFFFFF"), location: 0),
             .init(color: .init(hex: "FFFFFF").opacity(0.5), location: 0.5),
@@ -195,7 +195,6 @@ public enum HGGradient {
         startPoint: .topLeading,
         endPoint: .bottomTrailing
     )
-    
 }
 
 #Preview {
@@ -239,7 +238,7 @@ public enum HGGradient {
                 }
                 
                 GridRow {
-                    HGGradient.stroke30
+                    HGGradient.strokeGradient
                 }
                 .background(Color.black)
             }

--- a/Projects/UI/HGDesignSystem/Sources/Components/HGPhotoPickerView.swift
+++ b/Projects/UI/HGDesignSystem/Sources/Components/HGPhotoPickerView.swift
@@ -49,7 +49,7 @@ public struct HGPhotoPickerView: View {
         for imageItem in imageItems {
             guard let imageData = try? await imageItem.loadTransferable(type: Data.self),
                   let uiImage = UIImage(data: imageData) else {
-                return
+                continue
             }
             tempImages.append(uiImage)
         }

--- a/Projects/UI/HGDesignSystem/Sources/Components/HGPhotoPickerView.swift
+++ b/Projects/UI/HGDesignSystem/Sources/Components/HGPhotoPickerView.swift
@@ -1,0 +1,74 @@
+//
+//  HGPhotoPickerView.swift
+//  HGDesignSystem
+//
+//  Created by Enes on 6/26/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+public struct HGPhotoPickerView: View {
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @Binding private var images: [UIImage]
+    private let maxSelectCount: Int
+    
+    public init(images: Binding<[UIImage]>, maxSelectCount: Int) {
+        self._images = images
+        self.maxSelectCount = maxSelectCount
+    }
+    
+    public var body: some View {
+        PhotosPicker(
+            selection: $selectedItems,
+            maxSelectionCount: maxSelectCount,
+            selectionBehavior: .ordered,
+            matching: .images
+        ) {
+            VStack {
+                HGIcons.camera.image
+                    .resizable()
+                    .frame(24)
+                Text("\(selectedItems.count)/\(maxSelectCount)")
+                    .setTypo(.body_14_bold)
+            }
+            .foregroundStyle(.gray30)
+            .frame(85)
+            .strokeBorder(HGColors.gray20.color, radius: 12, linewidth: 1)
+        }
+        .onChange(of: selectedItems) { _, newValue in
+            Task {
+                await loadImage(newValue)
+            }
+        }
+    }
+    
+    @MainActor
+    private func loadImage(_ imageItems: [PhotosPickerItem]) async {
+        var tempImages: [UIImage] = []
+        for imageItem in imageItems {
+            guard let imageData = try? await imageItem.loadTransferable(type: Data.self),
+                  let uiImage = UIImage(data: imageData) else {
+                return
+            }
+            tempImages.append(uiImage)
+        }
+        images = tempImages
+    }
+}
+
+#Preview {
+    @Previewable @State var images: [UIImage] = []
+    
+    VStack {
+        HStack {
+            ForEach(images.indices, id: \.self) {
+                Image(uiImage: images[$0])
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .aspectRatio(contentMode: .fit)
+            }
+        }
+        HGPhotoPickerView(images: $images, maxSelectCount: 3)
+    }
+}

--- a/Projects/UI/HGDesignSystem/Sources/TimerView.swift
+++ b/Projects/UI/HGDesignSystem/Sources/TimerView.swift
@@ -11,7 +11,7 @@ public struct TimerView: View {
     private let time: String
     private let description: String
     private let backgroundColor: Color
-    private let borderColor: LinearGradient = HGGradient.stroke30
+    private let borderColor: LinearGradient = HGGradient.strokeGradient
     
     public init(
         time: String,


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #47 

##  📝 작업 내용

- HGPhotoPickerView 포토피커 컴포넌트 구현
  - 나중에 해당이미지 통신시 data로 압축해야해서 Image타입으로는 사용할 수 없기때문에 사용타입은 **UIImage**로 선택했습니다
- storke컬러 통합
  - stroke30 -> strokeGradient
  - 디자인에 stroke30, stroke60이 존재하는데 네이밍을 구분해서 만들수 없어서 통합했습니다
  - LinearGradient에 opacity를 주면 view형태로 반환되서 Shape를 매개변수로 갖는 곳에서 사용할 수 없기때문에 일반화시켰습니다.


### 포토피커 사용 예시코드

```swift
@State private var images: [UIImage] = []

VStack {
    HStack {
        ForEach(images.indices, id: \.self) {
            Image(uiImage: images[$0])
                .resizable()
                .frame(width: 100, height: 100)
                .aspectRatio(contentMode: .fit)
        }
    }
    HGPhotoPickerView(images: $images, maxSelectCount: 3)
}
```

## 📸 작업 스크린샷 (Optional)

![image](https://github.com/user-attachments/assets/7db61158-14bb-407e-9a41-11aa844e400d)

  

## 📣 그 외 알릴 내용
해결하지 못해 도움이 필요한 점, 리뷰에 참고하면 좋을점 등을 알려주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사진 라이브러리에서 여러 이미지를 선택할 수 있는 새로운 사진 선택기 컴포넌트가 추가되었습니다.

* **Refactor**
  * 기존 그라데이션 이름이 `stroke30`에서 `strokeGradient`로 변경되었습니다.
  * 타이머 뷰의 테두리 색상이 새로운 그라데이션 이름을 사용하도록 업데이트되었습니다.

* **Documentation**
  * 그라데이션 관련 문서 설명이 실제 적용되는 투명도 값을 더 정확하게 반영하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->