### PR TITLE
LongTextView 구현

### DIFF
--- a/Projects/UI/HGDesignSystem/Sources/Components/HGLongTextView.swift
+++ b/Projects/UI/HGDesignSystem/Sources/Components/HGLongTextView.swift
@@ -1,0 +1,92 @@
+//
+//  HGLongTextView.swift
+//  HGDesignSystem
+//
+//  Created by Enes on 6/26/25.
+//
+
+import SwiftUI
+
+public struct HGLongTextView: View {
+    @Binding private var text: String
+    private var isFocused: FocusState<Bool>.Binding
+    private let title: String
+    private let placeholder: String
+    private let maxCount: Int
+    
+    public init(
+        text: Binding<String>,
+        isFocused: FocusState<Bool>.Binding,
+        title: String,
+        placeholder: String,
+        maxCount: Int
+    ) {
+        self._text = text
+        self.isFocused = isFocused
+        self.title = title
+        self.placeholder = placeholder
+        self.maxCount = maxCount
+    }
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            titleView
+            Spacer().frame(height: 8)
+            textView
+            Spacer().frame(height: 4)
+            wordCountView
+        }
+    }
+    
+    private var titleView: some View {
+        HStack {
+            Text(title)
+                .setTypo(.caption_12_medium)
+                .foregroundStyle(.gray80)
+            Spacer()
+        }
+    }
+    
+    private var textView: some View {
+        TextField(placeholder, text: $text, axis: .vertical)
+            .setTypo(.body_14_regular)
+            .focused(isFocused)
+            .lineLimit(5, reservesSpace: true)
+            .padding(.horizontal, 16)
+            .frame(height: 120)
+            .background(.white)
+            .strokeBorder(
+                isFocused.wrappedValue ? HGColors.orange500Main.color : HGColors.gray40.color,
+                radius: 12,
+                linewidth: 1
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .onChange(of: text) { oldValue, newValue in
+                if newValue.count > maxCount {
+                    text = oldValue
+                }
+            }
+    }
+    
+    private var wordCountView: some View {
+        HStack {
+            Spacer()
+            Text("\(text.count) / \(maxCount)")
+                .setTypo(.caption_12_regular)
+                .foregroundStyle(.gray50)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var text: String = ""
+    @Previewable @FocusState var isFocused: Bool
+    
+    VStack {
+        HGLongTextView(text: $text, isFocused: $isFocused, title: "설명",placeholder: "입력해주세요",  maxCount: 100)
+    }
+    .onTapGesture {
+        isFocused = false
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #49 

##  📝 작업 내용
- HGLongTextView 구현 
  - 글자수제한
  - focus시 색변경
    - focus상태관리는 외부에서 하도록 구현했습니다. 내부에서 할때 키보드 내리는 동작을 하는데 어려움이있습니다

```swift
    @Previewable @State var text: String = ""
    @Previewable @FocusState var isFocused: Bool
    
    VStack {
        HGLongTextView(text: $text, isFocused: $isFocused, title: "설명",placeholder: "입력해주세요",  maxCount: 100)
    }
    .onTapGesture {
        isFocused = false
    }

```


<img width="660" alt="image" src="https://github.com/user-attachments/assets/95d24536-d16f-4a22-8fd2-9b2f8e4381c6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 제목, 플레이스홀더, 글자 수 제한이 포함된 확장 가능한 다중 행 텍스트 입력 컴포넌트가 추가되었습니다.
  * 입력 시 글자 수가 제한되며, 현재 글자 수가 하단에 표시됩니다.
  * 포커스 상태에 따라 입력란 테두리 색상이 변경됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->