### PR TITLE
네트워크 로직수정

### DIFF
--- a/Projects/Core/HGCommon/Sources/Extensions/Data+.swift
+++ b/Projects/Core/HGCommon/Sources/Extensions/Data+.swift
@@ -1,0 +1,17 @@
+//
+//  Data+.swift
+//  HGCommon
+//
+//  Created by Enes on 7/2/25.
+//
+
+import Foundation
+
+public extension Data {
+    var toPrettyPrintedString: String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return nil }
+        return prettyPrintedString as String
+    }
+}

--- a/Projects/Core/HGNetwork/Sources/Core/HGIntercepter.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/HGIntercepter.swift
@@ -34,7 +34,3 @@ final class HGIntercepter: RequestInterceptor {
         }
     }
 }
-
-
-
-

--- a/Projects/Core/HGNetwork/Sources/Core/HGIntercepter.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/HGIntercepter.swift
@@ -24,11 +24,9 @@ final class HGIntercepter: RequestInterceptor {
     ) {
         Task {
             do {
-                
                 var newURLRequest = urlRequest
                 let accessToken = try await keychain.readKeychain(key: .accessToken)
                 newURLRequest.headers.update(name: "Authorization", value: "Bearer \(accessToken)")
-                
                 completion(.success(newURLRequest))
             } catch {
                 completion(.failure(error))
@@ -36,3 +34,7 @@ final class HGIntercepter: RequestInterceptor {
         }
     }
 }
+
+
+
+

--- a/Projects/Core/HGNetwork/Sources/Core/HGNetworkFactory.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/HGNetworkFactory.swift
@@ -10,13 +10,15 @@ import Foundation
 import Alamofire
 
 public enum HGNetworkFactory {
-    public static func makeNetworkClient(
-        commonHeaders: HTTPHeaders = [:],
-        session: Session = .default
-    ) -> Networkable {
-        return NetworkClient(
-            commonHeaders: commonHeaders,
-            session: session
-        )
+    public static func makeNetworkClient(session: Session? = nil) -> Networkable {
+        if let session {
+            return NetworkClient(session: session)
+        } else {
+            let session = Session(
+                configuration: URLSessionConfiguration.af.default,
+                eventMonitors: [HGNetworkLogger()]
+            )
+            return NetworkClient(session: session)
+        }
     }
 }

--- a/Projects/Core/HGNetwork/Sources/Core/HGNetworkLogger.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/HGNetworkLogger.swift
@@ -1,0 +1,42 @@
+//
+//  HGNetworkLogger.swift
+//  HGNetwork
+//
+//  Created by Enes on 7/2/25.
+//
+
+import Alamofire
+
+import HGLogger
+
+struct HGNetworkLogger: EventMonitor {
+    func requestDidFinish(_ request: Request) {
+        #if DEBUG
+        LoggerUtil.log(
+        """
+        \n🌐🌐🌐🌐 Request 🌐🌐🌐🌐
+        URL: \(request.request?.url?.absoluteString ?? "nil")
+        Method: \(request.request?.httpMethod ?? "nil")
+        Header: \(request.request?.allHTTPHeaderFields ?? [:])
+        Body: \(request.request?.httpBody?.toPrettyPrintedString ?? "nil")
+        """
+        )
+        #endif
+    }
+    
+    func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
+        #if DEBUG
+        LoggerUtil.log(
+        """
+        \n✅✅✅✅ Response Value ✅✅✅✅
+        status code: \(response.response?.statusCode ?? -1)
+        Data: \(response.data?.toPrettyPrintedString ?? "nil")
+        """
+        )
+        #endif
+    }
+    
+    func request(_ request: Request, didFailToCreateURLRequestWithError error: AFError) {
+        LoggerUtil.log(error, level: .error)
+    }
+}

--- a/Projects/Core/HGNetwork/Sources/Core/NetworkClient.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/NetworkClient.swift
@@ -11,31 +11,23 @@ import Alamofire
 
 final class NetworkClient: Networkable {
     private let session: Session
-    private let commonHeaders: HTTPHeaders
-    private let interceptor: RequestInterceptor = HGIntercepter()
+    private let interceptor: any RequestInterceptor = HGIntercepter()
     private let jsonDecoder: JSONDecoder = .init()
     
-    init(
-        commonHeaders: HTTPHeaders = [:],
-        session: Session = .default
-    ) {
-        self.commonHeaders = commonHeaders
+    init(session: Session) {
         self.session = session
     }
     
     // MARK: - Send
     func send<T: EndPointable & Sendable>(
-        _ request: T,
-        intercepter: RequestInterceptor?
-    ) async throws(NetworkError) -> T.Response? {
-        let response = try await _send(request, interceptor: intercepter)
-        return try handleResponse(response)
-    }
-    
-    func send<T: EndPointable & Sendable>(
         _ request: T
     ) async throws(NetworkError) -> T.Response? {
-        let response = try await _send(request, interceptor: interceptor)
+        let requestInterceptor: RequestInterceptor? = if request.isNeedAuthorization {
+            interceptor
+        } else {
+            nil
+        }
+        let response = try await _send(request, interceptor: requestInterceptor)
         return try handleResponse(response)
     }
 

--- a/Projects/Core/HGNetwork/Sources/Core/NetworkClient.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/NetworkClient.swift
@@ -78,7 +78,7 @@ private extension NetworkClient {
                 method: request.method.toAFMethod,
                 parameters: request.parameters,
                 encoding: request.encoding.toAFEndcoding,
-                headers: commonHeaders,
+                headers: request.requestHeaders.toAFHeaders,
                 interceptor: interceptor
             )
             .validate()
@@ -109,7 +109,7 @@ private extension NetworkClient {
                 },
                 to: url,
                 method: request.method.toAFMethod,
-                headers: commonHeaders
+                headers: request.requestHeaders.toAFHeaders
             )
             .serializingDecodable(T.Response.self)
             .response

--- a/Projects/Core/HGNetwork/Sources/Core/Networkable.swift
+++ b/Projects/Core/HGNetwork/Sources/Core/Networkable.swift
@@ -10,7 +10,6 @@ import Foundation
 import Alamofire
 
 public protocol Networkable {
-    func send<T: EndPointable & Sendable>(_ request: T, intercepter: RequestInterceptor?) async throws(NetworkError) -> T.Response?
     func send<T: EndPointable & Sendable>(_ request: T) async throws(NetworkError) -> T.Response?
     
     func upload<T: MultipartRequestable>(_ request: T) async throws(NetworkError) -> T.Response?

--- a/Projects/Core/HGNetwork/Sources/Protocol/EndPointable.swift
+++ b/Projects/Core/HGNetwork/Sources/Protocol/EndPointable.swift
@@ -17,11 +17,23 @@ public protocol EndPointable {
     var parameters: HGParameters? { get }
     var headers: HGHTTPHeaders? { get }
     var encoding: HGParameterEncoding { get }
+    var isNeedAuthorization: Bool { get }
 }
 
 public extension EndPointable {
     var encoding: HGParameterEncoding {
         method == .get ? .urlEncoding : .jsonEncoding
+    }
+    var isNeedAuthorization: Bool { false }
+    var requestHeaders: HGHTTPHeaders {
+        var tempHeader: HGHTTPHeaders = [:]
+        if headers?["Content-Type"] == nil {
+            tempHeader.updateValue("application/json", forKey: "Content-Type")
+        }
+        self.headers?.forEach {
+            tempHeader.updateValue($0.value, forKey: $0.key)
+        }
+        return tempHeader
     }
 }
 

--- a/Projects/Data/User/Sources/UserRepositoryImpl.swift
+++ b/Projects/Data/User/Sources/UserRepositoryImpl.swift
@@ -32,7 +32,7 @@ public final class UserRepositoryImpl: UserRepository {
         let api = SignUpAPI(parameters: parameters)
         
         do {
-            guard let dtoModel = try await network.send(api, intercepter: nil),
+            guard let dtoModel = try await network.send(api),
                   let data = dtoModel.data else {
                 throw HGError.domainError("dto model is nil")
             }
@@ -64,7 +64,7 @@ public final class UserRepositoryImpl: UserRepository {
         let api = GetProfileListAPI(parameters: nil)
         
         do {
-            guard let dtoModel = try await network.send(api, intercepter: nil) else {
+            guard let dtoModel = try await network.send(api) else {
                 throw HGError.domainError("dto model is nil")
             }
             


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #70 

##  📝 작업 내용
- Session생성변경
- 공통헤더 추가로직 변경
- 네트워크 모니터 로그 추가
- 인터셉터 외부주입 프로토콜 삭제
- auth관련 인터셉터 로직 추가

### 헤더변경사항
EndPointable의 `var headers: HGHTTPHeaders? { get }`
에 정의된 헤더를 공통 헤더와 합쳐서 제공하는 코드가 아래 requestHeaders입니다
각 api에필요한 헤더만 정의해서 사용하면됩니다

``` swift
var requestHeaders: HGHTTPHeaders {
    var tempHeader: HGHTTPHeaders = [:]
    if headers?["Content-Type"] == nil {
        tempHeader.updateValue("application/json", forKey: "Content-Type")
    }
    self.headers?.forEach {
        tempHeader.updateValue($0.value, forKey: $0.key)
    }
    return tempHeader
}
```


## 📣 그 외 알릴 내용
프로토콜 수정에따라서 외부모듈은 userRepository쪽만 수정이뤄졌습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 네트워크 요청 및 응답 정보를 디버그 모드에서 로깅하는 기능이 추가되었습니다.
  * Data 타입에 JSON 데이터를 보기 좋게 출력하는 기능이 추가되었습니다.

* **기능 개선**
  * 네트워크 클라이언트 생성 방식이 간소화되어, 세션 설정과 로깅이 기본 적용됩니다.
  * 공통 헤더 관리가 각 요청 단위로 변경되어, 헤더 처리 방식이 더욱 유연해졌습니다.
  * 요청 시 인증 필요 여부를 명확하게 지정할 수 있습니다.

* **코드 개선**
  * 불필요한 인터셉터 파라미터와 관련 메서드가 제거되어 인터페이스가 단순화되었습니다.
  * 스타일 및 불필요한 공백이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->