### PR TITLE
프로필수정 UI구현

### DIFF
--- a/Projects/App/Sources/HGDGDSiOSApp.swift
+++ b/Projects/App/Sources/HGDGDSiOSApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import HGDesignSystem
 
 @main
 struct HGDGDSiOSApp: App {
@@ -6,6 +7,7 @@ struct HGDGDSiOSApp: App {
     
     init() {
         DependencyConfiguration.configure()
+        UIFont.registerAllFont()
     }
     
     var body: some Scene {

--- a/Projects/Data/MyPage/Project.swift
+++ b/Projects/Data/MyPage/Project.swift
@@ -16,6 +16,7 @@ let project = Project(
             name: "MyPageData",
             dependencies: [
                 .domainProject(with: .myPage),
+                .domainProject(with: .user),
                 .coreProject(with: .hgCommon),
                 .coreProject(with: .hgNetwork)
             ],

--- a/Projects/Features/MyPage/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Projects/Features/MyPage/Sources/Coordinator/MyPageCoordinator.swift
@@ -26,7 +26,7 @@ public final class MyPageCoordinator: Coordinatorable {
         switch screen {
         case .main: MyPageView()
         case .setting: SettingView()
-        case .editProfile: Color.red
+        case .editProfile: EditProfileView()
         }
     }
     

--- a/Projects/Features/MyPage/Sources/EditProfile/EditProfileView.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/EditProfileView.swift
@@ -1,0 +1,48 @@
+//
+//  EditProfileView.swift
+//  MyPageFeature
+//
+//  Created by Enes on 7/2/25.
+//
+
+import SwiftUI
+import HGDesignSystem
+import NukeUI
+
+struct EditProfileView: View {
+    @State private var viewModel: EditProfileViewModel = .init()
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer().frame(height: 27)
+            ProfileImagePicker(itemList: viewModel.candidateProfiles, selectedItem: $viewModel.state.selectedProfile)
+            Spacer().frame(height: 44)
+            HGTextField(
+                title: "닉네임",
+                text: .init(
+                    get: { viewModel.nickname },
+                    set: { viewModel.reduce(.updateNickname($0)) }
+                ),
+                placeholder: "닉네임을 입력해 주세요",
+                size: .default,
+                maxCount: 6,
+                hiddenClearButton: true,
+                errorMessage: viewModel.errorMessage,
+                required: true
+            )
+            Spacer()
+            HGButton(title: "저장", size: .xLarge, variant: .primary, isMaxWidth: true) {
+                viewModel.reduce(.didTapSaveButton)
+            }
+            .disabled(viewModel.isDisabledSaveButton)
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+        .applyNavigationBar(title: "프로필 편집")
+    }
+}
+
+#Preview(traits: .applyFont) {
+    EditProfileView()
+}
+

--- a/Projects/Features/MyPage/Sources/EditProfile/EditProfileView.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/EditProfileView.swift
@@ -15,7 +15,13 @@ struct EditProfileView: View {
     var body: some View {
         VStack(spacing: 0) {
             Spacer().frame(height: 27)
-            ProfileImagePicker(itemList: viewModel.candidateProfiles, selectedItem: $viewModel.state.selectedProfile)
+            ProfileImagePicker(
+                itemList: viewModel.candidateProfiles,
+                selectedItem: .init(
+                    get: { viewModel.selectedProfile },
+                    set: { viewModel.reduce(.updateProfile($0)) }
+                )
+            )
             Spacer().frame(height: 44)
             HGTextField(
                 title: "닉네임",
@@ -39,6 +45,9 @@ struct EditProfileView: View {
         .padding(.horizontal, 16)
         .padding(.bottom, 12)
         .applyNavigationBar(title: "프로필 편집")
+        .onAppear {
+            viewModel.reduce(.onAppear)
+        }
     }
 }
 

--- a/Projects/Features/MyPage/Sources/EditProfile/EditProfileViewModel.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/EditProfileViewModel.swift
@@ -16,12 +16,13 @@ final class EditProfileViewModel: Reducerable {
         case onAppear
         case didTapSaveButton
         case updateNickname(String)
+        case updateProfile(KokProfile?)
     }
     
     struct State {
         var nickname: String = ""
-        var selectedProfile: KoKProfile?
-        var candidateProfiles: [KoKProfile] = []
+        var selectedProfile: KokProfile?
+        var candidateProfiles: [KokProfile] = []
         var isDisabledSaveButton: Bool = true
         var errorMessage: String?
     }
@@ -34,13 +35,17 @@ final class EditProfileViewModel: Reducerable {
     func reduce(_ action: Action) {
         switch action {
         case .onAppear:
-            state.selectedProfile = nil
-            state.nickname = ""
+            state.selectedProfile = stubItems[0]
+            state.nickname = "테스트"
+            state.candidateProfiles = stubItems
         case .didTapSaveButton:
             print("통신")
         case let .updateNickname(text):
             state.nickname = text
             state.errorMessage = isValidateNickname(text) ? nil : "닉네임은 텍스트만 입력 가능합니다"
+            state.isDisabledSaveButton = !isValidationSaveButton()
+        case let .updateProfile(profile):
+            state.selectedProfile = profile
             state.isDisabledSaveButton = !isValidationSaveButton()
         }
     }
@@ -51,5 +56,17 @@ final class EditProfileViewModel: Reducerable {
     
     private func isValidationSaveButton() -> Bool {
         !state.nickname.isEmpty && state.errorMessage == nil && state.selectedProfile != nil
+    }
+}
+
+extension EditProfileViewModel {
+    private var stubItems: [KokProfile] {
+        [
+            .init(id: "1", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "2", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "3", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "4", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "5", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+        ]
     }
 }

--- a/Projects/Features/MyPage/Sources/EditProfile/EditProfileViewModel.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/EditProfileViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  EditProfileViewModel.swift
+//  MyPageFeature
+//
+//  Created by Enes on 7/3/25.
+//
+
+import Foundation
+
+import HGCommon
+import UserDomain
+
+@Observable
+final class EditProfileViewModel: Reducerable {
+    enum Action {
+        case onAppear
+        case didTapSaveButton
+        case updateNickname(String)
+    }
+    
+    struct State {
+        var nickname: String = ""
+        var selectedProfile: KoKProfile?
+        var candidateProfiles: [KoKProfile] = []
+        var isDisabledSaveButton: Bool = true
+        var errorMessage: String?
+    }
+    
+    var state: State = .init()
+    
+    @ObservationIgnored
+    @Dependency var usecase: any UserUseCase
+    
+    func reduce(_ action: Action) {
+        switch action {
+        case .onAppear:
+            state.selectedProfile = nil
+            state.nickname = ""
+        case .didTapSaveButton:
+            print("통신")
+        case let .updateNickname(text):
+            state.nickname = text
+            state.errorMessage = isValidateNickname(text) ? nil : "닉네임은 텍스트만 입력 가능합니다"
+            state.isDisabledSaveButton = !isValidationSaveButton()
+        }
+    }
+    
+    private func isValidateNickname(_ name: String) -> Bool {
+        usecase.validateNickname(nickname: name)
+    }
+    
+    private func isValidationSaveButton() -> Bool {
+        !state.nickname.isEmpty && state.errorMessage == nil && state.selectedProfile != nil
+    }
+}

--- a/Projects/Features/MyPage/Sources/EditProfile/KoKProfile.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/KoKProfile.swift
@@ -1,0 +1,13 @@
+//
+//  KoKProfile.swift
+//  MyPageFeature
+//
+//  Created by Enes on 7/3/25.
+//
+
+import HGDesignSystem
+
+struct KoKProfile: ProfileImagePickable, Equatable {
+    var id: String
+    var imageUrl: String
+}

--- a/Projects/Features/MyPage/Sources/EditProfile/KokProfile.swift
+++ b/Projects/Features/MyPage/Sources/EditProfile/KokProfile.swift
@@ -1,5 +1,5 @@
 //
-//  KoKProfile.swift
+//  KokProfile.swift
 //  MyPageFeature
 //
 //  Created by Enes on 7/3/25.
@@ -7,7 +7,7 @@
 
 import HGDesignSystem
 
-struct KoKProfile: ProfileImagePickable, Equatable {
+struct KokProfile: ProfileImagePickable, Equatable {
     var id: String
     var imageUrl: String
 }

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
@@ -10,6 +10,7 @@ import HGDesignSystem
 
 struct MyPageView: View {
     @Environment(MyPageCoordinator.self) var coordinator
+    @Environment(HGTabViewManager.self) var tabManager
     
     var body: some View {
         ZStack {
@@ -31,6 +32,9 @@ struct MyPageView: View {
             .applyTabbarHeight(padding: 38)
             .fillMaxSize(.top)
             .overlay(alignment: .topTrailing) { settingButton }
+        }
+        .onAppear {
+            tabManager.setTabBarHidden(false)
         }
     }
     

--- a/Projects/Features/MyPage/Sources/Setting/SettingView.swift
+++ b/Projects/Features/MyPage/Sources/Setting/SettingView.swift
@@ -11,6 +11,7 @@ import HGDesignSystem
 struct SettingView: View {
     @State private var viewModel: SettingViewModel = .init()
     @Environment(MyPageCoordinator.self) var coordinator
+    @Environment(HGTabViewManager.self) var tabManager
     
     var body: some View {
         VStack(spacing: 24) {
@@ -23,7 +24,10 @@ struct SettingView: View {
         .padding(.horizontal, 16)
         .padding(.top, 26)
         .applyNavigationBar(title: "설정")
-        .onAppear { viewModel.reduce(.setup) }
+        .onAppear {
+            viewModel.reduce(.setup)
+            tabManager.setTabBarHidden(true)
+        }
     }
     
     private var profileView: some View {

--- a/Projects/UI/HGDesignSystem/Sources/Components/ProfileImagePicker/ProfileImagePicker.swift
+++ b/Projects/UI/HGDesignSystem/Sources/Components/ProfileImagePicker/ProfileImagePicker.swift
@@ -17,6 +17,9 @@ public protocol ProfileImagePickable: Identifiable {
 public struct ProfileImagePicker<Item: ProfileImagePickable & Equatable>: View {
     private var itemList: [Item]
     @Binding private var selectedItem: Item?
+    private let thumbnailSize: CGFloat = 58
+    private let thumbnailInnerPadding: CGFloat = 4
+    private let thumbnailSpacing: CGFloat = 7
     
     public init(
         itemList: [Item],
@@ -38,38 +41,70 @@ public struct ProfileImagePicker<Item: ProfileImagePickable & Equatable>: View {
                 }
             }
             .frame(180)
-            .setRadius(180/2 - 10)
+            .setRadius(70)
             .padding(.bottom, 22)
-            ScrollView(.horizontal) {
-                HStack(spacing: 7) {
-                    ForEach(itemList, id: \.id) { item in
-                        Button {
-                            withAnimation(.spring(duration: 0.35)) { selectedItem = item }
-                        } label: {
-                            LazyImage(url: .init(string: item.imageUrl)) { state in
-                                if let image = state.image {
-                                    image.resizable()
-                                        .scaledToFit()
-                                } else {
-                                    HGColors.opacityBlack10.color
+            GeometryReader { proxy in
+                ScrollView(.horizontal) {
+                    HStack(spacing: thumbnailSpacing) {
+                        ForEach(itemList, id: \.id) { item in
+                            Button {
+                                withAnimation(.spring(duration: 0.35)) { selectedItem = item }
+                            } label: {
+                                LazyImage(url: .init(string: item.imageUrl)) { state in
+                                    if let image = state.image {
+                                        image
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(thumbnailSize)
+                                    } else {
+                                        HGColors.opacityBlack10.color
+                                    }
                                 }
+                                .setRadius(24)
                             }
-                            .frame(58)
-                            .scaledToFit()
-                            .setRadius(58/2 - 3)
-                            .padding(4)
-                            .if(item.id == selectedItem?.id) {
-                                $0.strokeBorder(
-                                    HGColors.orange500Main.color,
-                                    radius: 66/2 - 3,
-                                    linewidth: 2
-                                )
-                            }
+                            .frame(thumbnailSize)
+                            .padding(thumbnailInnerPadding)
+                            .strokeBorder(
+                                item.id == selectedItem?.id ? HGColors.orange500Main.color : .clear,
+                                radius: 24,
+                                linewidth: 2
+                            )
                         }
                     }
                 }
+                .scrollIndicators(.hidden)
+                .contentMargins(
+                    .leading,
+                    centerPadding(screenWidth: proxy.frame(in: .global).width),
+                    for: .scrollContent
+                )
             }
-            .scrollIndicators(.hidden)
+            .frame(height: thumbnailSize + thumbnailInnerPadding * 2)
         }
     }
+    
+    private func centerPadding(screenWidth: CGFloat) -> CGFloat {
+        let width: CGFloat = (thumbnailSize + thumbnailInnerPadding * 2) * CGFloat(itemList.count)
+        let spacing: CGFloat = thumbnailSpacing * CGFloat(itemList.count - 1)
+        return (screenWidth - (width + spacing)) / 2
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedItem: StubProfileInfo?
+    var items: [StubProfileInfo] {
+        [
+            .init(id: "1", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "2", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "3", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "4", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+            .init(id: "5", imageUrl: "https://i.pinimg.com/236x/34/ee/4d/34ee4d418a30e5ca3faf307386591fa7.jpg"),
+        ]
+    }
+    ProfileImagePicker(itemList: items, selectedItem: $selectedItem)
+}
+
+private struct StubProfileInfo: ProfileImagePickable, Equatable {
+    var id: String
+    var imageUrl: String
 }


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #38 


##  📝 작업 내용
- 폰트적용
- 프로필 편집 UI구현
- `ProfileImagePicker` 프로필 피커 센터정렬 및 컴포넌트 크기 재조정
  - 중앙정렬을위한 수치계산 로직추가
  - 이미지 radius 수정에따라서 수치 변경
  - Preview 제공


## 📸 작업 스크린샷 (Optional)

|제목1|
|:---:|
|![image](https://github.com/user-attachments/assets/d2cbb2a2-9235-4602-b839-fe5a44bb449d)|
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필 편집 화면이 추가되었습니다. 프로필 이미지 선택, 닉네임 입력 및 저장 기능을 지원합니다.
  * 프로필 이미지 선택 컴포넌트가 개선되어 썸네일 정렬 및 스타일링이 향상되었습니다.

* **버그 수정**
  * 마이페이지 및 설정 화면 진입 시 탭 바의 표시/숨김 상태가 명확하게 동작하도록 개선되었습니다.

* **리팩터**
  * 앱 시작 시 폰트가 자동으로 등록되어 일관된 디자인이 적용됩니다.

* **기타**
  * 내부 의존성 및 데이터 구조가 확장되어 향후 기능 개발이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->