### PR TITLE
홈 성능 최적화 및 코드정리

### DIFF
--- a/Projects/Core/HGCommon/Sources/TimerManager/CountDownTimerManager.swift
+++ b/Projects/Core/HGCommon/Sources/TimerManager/CountDownTimerManager.swift
@@ -11,13 +11,13 @@ import Foundation
 public final class CountDownTimerManager {
     private let timer: TimerManager = TimerManager()
     /// 2025-07-11T19:00:00+09:00
-    private var endDate: Date?
-    private var remainTime: TimeInterval { ceil(endDate?.timeIntervalSinceNow ?? 0) }
+    @ObservationIgnored private var endDate: Date?
+    @ObservationIgnored private var remainTime: TimeInterval { ceil(endDate?.timeIntervalSinceNow ?? 0) }
     
     public private(set) var hours: String = "00"
     public private(set) var minutes: String = "00"
     public private(set) var seconds: String = "00"
-    public var fullTimeString: String { "\(hours) : \(minutes) : \(seconds)" }
+    @ObservationIgnored public var fullTimeString: String { "\(hours) : \(minutes) : \(seconds)" }
     
     public init() {
         bind()

--- a/Projects/Features/CreateReservation/Sources/CreateReservationView.swift
+++ b/Projects/Features/CreateReservation/Sources/CreateReservationView.swift
@@ -77,9 +77,16 @@ struct CreateReservationView: View {
                     "",
                     selection: .init(
                         get: { viewModel.selectedTime ?? .now },
-                        set: { viewModel.reduce(.didSelectTime($0)) }
+                        set: {
+                            let selectedDate = viewModel.selectedDate ?? .now
+                            let fullDateTime = selectedDate.addingTimeInterval($0.timeIntervalSinceNow)
+                            if fullDateTime > Date.now {
+                                viewModel.reduce(.didSelectTime($0))
+                            } else {
+                                viewModel.reduce(.didSelectTime(.now))
+                            }
+                        }
                     ),
-                    in: Date.now...,
                     displayedComponents: [.hourAndMinute]
                 )
                 .datePickerStyle(.wheel)

--- a/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
@@ -68,7 +68,9 @@ private struct MainReservationView: View {
     var body: some View {
         VStack(spacing: 0) {
             headerText
-            
+                .background(alignment: .top) {
+                    categoryImage
+                }
             if isShowSubReservationCardList {
                 Spacer().frame(height: 42)
             } else {
@@ -93,6 +95,14 @@ private struct MainReservationView: View {
             .setTypo(.body_16_medium)
             .foregroundStyle(.gray0White)
             .shadow(color: reservationInfo.categoryType.darkColor.color, radius: 20)
+    }
+    
+    @ViewBuilder
+    private var categoryImage: some View {
+        reservationInfo.categoryType.image
+            .resizable()
+            .frame(354)
+            .transition(.move(edge: .leading).combined(with: .opacity))
     }
 }
 

--- a/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
@@ -36,6 +36,7 @@ struct HomeMainReservationTabView: View {
                 .padding(.bottom, HomeUIConstans.bottomPadding)
                 .tag(index)
             }
+            .toolbarVisibility(.hidden, for: .tabBar)
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .frame(height: mainReservationTabViewHeight)

--- a/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeMainReservationTabView.swift
@@ -64,10 +64,6 @@ private struct MainReservationView: View {
     let reservationInfo: ReservationInfo
     let isShowSubReservationCardList: Bool
     let action: () -> Void
-    
-    @State var countDownTimer: CountDownTimerManager = .init()
-    
-    var dDay: Int { reservationInfo.reservationDatetime.dDayValue() }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -79,13 +75,7 @@ private struct MainReservationView: View {
                 Spacer().frame(maxHeight: 70)
             }
             
-            ReservationTimerView(
-                category: reservationInfo.categoryType,
-                dDay: dDay,
-                hours: countDownTimer.hours,
-                minutes: countDownTimer.minutes,
-                seconds: countDownTimer.seconds
-            )
+            ReservationTimerView(reservationInfo: reservationInfo)
             
             Spacer().frame(minHeight: 33)
             
@@ -95,13 +85,7 @@ private struct MainReservationView: View {
         }
         .padding(.top, isShowSubReservationCardList ? 20 : 44)
         .padding(.horizontal, 16)
-        .onAppear {
-            countDownTimer.setupTime(endDate: reservationInfo.reservationDatetime)
-            countDownTimer.start()
-        }
-        .onDisappear {
-            countDownTimer.stop()
-        }
+        
     }
     
     private var headerText: some View {
@@ -113,11 +97,16 @@ private struct MainReservationView: View {
 }
 
 private struct ReservationTimerView: View {
+    @State private var countDownTimer: CountDownTimerManager = .init()
     let category: ReservationCategoryType
-    var dDay: Int
-    var hours: String
-    var minutes: String
-    var seconds: String
+    let endDate: Date
+    let dDay: Int
+    
+    init(reservationInfo: ReservationInfo) {
+        self.category = reservationInfo.categoryType
+        self.endDate = reservationInfo.reservationDatetime
+        self.dDay = reservationInfo.reservationDatetime.dDayValue()
+    }
     
     var body: some View {
         VStack(spacing: 8) {
@@ -125,7 +114,7 @@ private struct ReservationTimerView: View {
             
             HStack(spacing: 4) {
                 TimerView(
-                    time: hours,
+                    time: countDownTimer.hours,
                     description: "시간",
                     backgroundColor: category.opacityColor.color
                 )
@@ -133,7 +122,7 @@ private struct ReservationTimerView: View {
                 colon
                 
                 TimerView(
-                    time: minutes,
+                    time: countDownTimer.minutes,
                     description: "분",
                     backgroundColor: category.opacityColor.color
                 )
@@ -141,11 +130,18 @@ private struct ReservationTimerView: View {
                 colon
                 
                 TimerView(
-                    time: seconds,
+                    time: countDownTimer.seconds,
                     description: "초",
                     backgroundColor: category.opacityColor.color
                 )
             }
+        }
+        .onAppear {
+            countDownTimer.setupTime(endDate: endDate)
+            countDownTimer.start()
+        }
+        .onDisappear {
+            countDownTimer.stop()
         }
     }
     

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -31,18 +31,17 @@ struct HomeView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     header
-                    
-                    TransitionTabSwitcherView(selectedTab: viewModel.selectedStatusTab) {
+                    if viewModel.selectedStatusTab == .scheduled {
                         scheduledReservationView
-                    } completedView: {
+                            .transition(.move(edge: .leading).combined(with: .opacity))
+                    } else if viewModel.selectedStatusTab == .completed {
                         completedReservationView
+                            .transition(.move(edge: .trailing).combined(with: .opacity))
                     }
                 }
                 .padding(.bottom, UIConstant.tabBarHeight)
                 .fillMaxSize(.top)
-                .background(alignment: .top) {
-                    categoryImage
-                }
+               
             }
         }
         .animation(.easeOut(duration: 0.35), value: viewModel.selectedStatusTab)
@@ -134,23 +133,6 @@ struct HomeView: View {
         }
     }
     
-    private var categoryImage: some View {
-        TransitionTabSwitcherView(selectedTab: viewModel.selectedStatusTab) {
-            Group {
-                if viewModel.isExistScheduledMainReservation {
-                    viewModel.mainReservationInfos[safe: viewModel.selectedReservationIndex]?.categoryType.image
-                        .resizable()
-                        .frame(354)
-                        .offset(y: viewModel.isExistScheduledSubReservations ? 32 : 96)
-                        .transition(.move(edge: .leading).combined(with: .opacity))
-                }
-            }
-        } completedView: {
-            Color.clear
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-        }
-    }
-    
     private var header: some View {
         ReservationStatusToggle(selectedTab: $viewModel.state.selectedStatusTab)
             .frame(width: 154, height: 40)
@@ -203,24 +185,6 @@ private struct ReservationStatusToggle: View {
             selectedTab == .scheduled ? .gray90 : .gray40
         case .completed:
             selectedTab == .completed ? .gray90 : .gray0White
-        }
-    }
-}
-
-private struct TransitionTabSwitcherView<FirstView: View, SecondView: View>: View {
-    let selectedTab: ReservationStatusTab
-    let scheduledView: () -> FirstView
-    let completedView: () -> SecondView
-
-    var body: some View {
-        ZStack {
-            if selectedTab == .scheduled {
-                scheduledView()
-                    .transition(.move(edge: .leading).combined(with: .opacity))
-            } else if selectedTab == .completed {
-                completedView()
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
-            }
         }
     }
 }

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -159,6 +159,7 @@ struct HomeView: View {
 }
 
 private struct ReservationStatusToggle: View {
+    @Namespace var namespace
     @Binding var selectedTab: ReservationStatusTab
 
     var body: some View {
@@ -167,7 +168,6 @@ private struct ReservationStatusToggle: View {
             
             tabItem(type: .completed)
         }
-        .animation(.easeInOut, value: selectedTab)
         .background(.opacityBlack10)
         .clipShape(Capsule())
         .frame(width: 154, height: 40)
@@ -185,8 +185,13 @@ private struct ReservationStatusToggle: View {
                 .background {
                     if selectedTab == type {
                         Capsule()
-                            .foregroundStyle(HGColors.gray0White)
+                            .foregroundStyle(HGColors.gray0White.color)
                             .padding([.vertical, type == .scheduled ? .leading : .trailing], 4)
+                            .animation(.spring, value: selectedTab)
+                            .matchedGeometryEffect(
+                                id: "tabItem",
+                                in: namespace.self
+                            )
                     }
                 }
         }

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -29,14 +29,26 @@ struct HomeView: View {
                 .ignoresSafeArea()
 
             ScrollView {
-                VStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
                     header
                     if viewModel.selectedStatusTab == .scheduled {
                         scheduledReservationView
-                            .transition(.move(edge: .leading).combined(with: .opacity))
+                            .transition(
+                                .asymmetric(
+                                    insertion: .move(edge: .leading),
+                                    removal: .move(edge: .trailing)
+                                )
+                                .combined(with: .opacity)
+                            )
                     } else if viewModel.selectedStatusTab == .completed {
                         completedReservationView
-                            .transition(.move(edge: .trailing).combined(with: .opacity))
+                            .transition(
+                                .asymmetric(
+                                    insertion: .move(edge: .trailing),
+                                    removal: .move(edge: .leading)
+                                )
+                                .combined(with: .opacity)
+                            )
                     }
                 }
                 .padding(.bottom, UIConstant.tabBarHeight)
@@ -44,8 +56,7 @@ struct HomeView: View {
                
             }
         }
-        .animation(.easeOut(duration: 0.35), value: viewModel.selectedStatusTab)
-        .animation(.easeInOut(duration: 0.25), value: viewModel.selectedReservationIndex)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.selectedStatusTab)
         .onAppear {
             tabManager.setTabBarHidden(false)
             viewModel.reduce(.onAppear)
@@ -169,13 +180,13 @@ private struct ReservationStatusToggle: View {
                         Capsule()
                             .foregroundStyle(HGColors.gray0White.color)
                             .padding([.vertical, type == .scheduled ? .leading : .trailing], 4)
-                            .animation(.spring, value: selectedTab)
                             .matchedGeometryEffect(
                                 id: "tabItem",
                                 in: namespace.self
                             )
                     }
                 }
+                .animation(.spring(bounce: 0.35), value: selectedTab)
         }
     }
     

--- a/Projects/Features/Home/Sources/Home/HomeViewModel.swift
+++ b/Projects/Features/Home/Sources/Home/HomeViewModel.swift
@@ -36,15 +36,17 @@ final class HomeViewModel: Reducerable {
         case onAppear
         case loadMoreReservation(status: ReservationListRequest.Status)
     }
-
+    
+    var isExistScheduledMainReservation: Bool { !state.mainReservationInfos.isEmpty }
+    var isExistScheduledSubReservations: Bool {
+        !state.scheduledReservationInfos.isEmpty
+    }
+    var isExistCompleteReservation: Bool { !state.completedReservationInfos.isEmpty }
+    
     struct State {
         var selectedStatusTab: ReservationStatusTab = .scheduled
         var selectedReservationIndex: Int = 0
         
-        var isExistScheduledMainReservation: Bool { !mainReservationInfos.isEmpty }
-        var isExistScheduledSubReservations: Bool { !scheduledReservationInfos.isEmpty }
-        var isExistCompleteReservation: Bool { !completedReservationInfos.isEmpty }
-
         var mainReservationInfos: [ReservationInfo] = []
         var scheduledReservationInfos: [ReservationInfo] = []
         var completedReservationInfos: [ReservationInfo] = []

--- a/Projects/Features/Onboarding/Sources/Screen/Onboarding/OnboardingSlidesView.swift
+++ b/Projects/Features/Onboarding/Sources/Screen/Onboarding/OnboardingSlidesView.swift
@@ -54,6 +54,7 @@ struct OnboardingSlidesView: View {
                 }
                 .tag(tab)
             }
+            .toolbarVisibility(.hidden, for: .tabBar)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         .padding(.top, 34)

--- a/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputView.swift
+++ b/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputView.swift
@@ -71,9 +71,17 @@ struct ReservationResultInputView: View {
                 "",
                 selection: .init(
                     get: { viewModel.successReservationTime ?? .now },
-                    set: { viewModel.reduce(.didChangeTime($0)) }
+                    set: {
+                        viewModel.reduce(.didChangeTime($0))
+                        let selectedDate = viewModel.successReservationDate ?? .now
+                        let fullDateTime = selectedDate.addingTimeInterval($0.timeIntervalSinceNow)
+                        if fullDateTime > Date.now {
+                            viewModel.reduce(.didChangeTime($0))
+                        } else {
+                            viewModel.reduce(.didChangeTime(.now))
+                        }
+                    }
                 ),
-                in: Date.now...,
                 displayedComponents: [.hourAndMinute]
             )
             .datePickerStyle(.wheel)

--- a/Projects/UI/HGDesignSystem/Sources/TabView/HGTabViewManager.swift
+++ b/Projects/UI/HGDesignSystem/Sources/TabView/HGTabViewManager.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 @Observable
 final public class HGTabViewManager {
     public private(set) var hiddenTabBar: Bool = false


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #92 
 

##  📝 작업 내용

- 텝바관련 메인스레드 경고 제거
- 타이머관련 뷰재생성 되는 로직 최적화 
  - `MainReservationView` 1초마다 뷰 재생성 되지않도록 최적화시켰어요~
- 홈 예정/완료 탭 애니메이션 바우스로 변경 
- 중복되거나 불필요한 뷰타입 정리 및 최적화
- 애니메이션 최적화
- 예약 시간설정시 미래시간 허용으로 로직수정
  - 2025.07.12일 오후 10시 00분 일떄
  - as-is 2025.07.13 오후 2시 예약 불가능 (기존로직이 현재시간을 바라봐서 현재시간기준 미래시간만 가능했음)
  - to-be 2025.07.13 오후 2시 예약 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약 홈 화면에서 카테고리 이미지를 상단 배경에 표시하는 기능이 추가되었습니다.
  * 예약 상태 토글에 탭 전환 애니메이션(매치드 지오메트리 효과)이 적용되었습니다.

* **버그 수정**
  * 예약 생성 및 결과 입력 시 시간 선택 로직이 개선되어, 과거 시간이 선택될 경우 자동으로 현재 시간으로 설정됩니다.
  * 시간 선택 DatePicker의 선택 가능 범위 제한이 제거되어 모든 시간이 표시되지만, 미래 시간만 유효하게 처리됩니다.

* **리팩터**
  * 홈 화면 예약 타이머가 각 예약 정보별로 독립적으로 관리되도록 구조가 개선되었습니다.
  * 예약 상태 전환 애니메이션이 더욱 자연스럽게 변경되었습니다.

* **스타일**
  * 홈 화면 예약 상태 토글의 캡슐 배경 스타일이 개선되었습니다.
  * 예약 홈 화면의 카테고리 이미지에 트랜지션 효과가 적용되었습니다.

* **기타**
  * 일부 내부 상태 및 관찰 속성의 동작 방식이 변경되어 앱의 반응성이 향상되었습니다.
  * Onboarding 및 홈 화면에서 탭 바 툴바가 숨겨집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->