### PR TITLE
[#97] Feat: 예약공유 QA수정

### DIFF
--- a/Projects/Data/CreateReservation/Sources/DTO/CreateReservationDTO.swift
+++ b/Projects/Data/CreateReservation/Sources/DTO/CreateReservationDTO.swift
@@ -27,10 +27,10 @@ extension CreateReservationDTO {
             reservationId: self.reservationId,
             title: self.title,
             category: self.category,
-            reservationDatetime: reservationDatetime.toDate(with: .iso8601ms),
+            reservationDatetime: reservationDatetime.toDate(with: .iso8601),
             linkUrl: linkUrl,
             hostId: hostId,
-            createAt: createdAt.toDate(with: .iso8601ms)
+            createAt: createdAt.toDate(with: .iso8601)
         )
     }
 }

--- a/Projects/Data/Reservation/Sources/DTO/ReservationDetailDTO.swift
+++ b/Projects/Data/Reservation/Sources/DTO/ReservationDetailDTO.swift
@@ -27,12 +27,12 @@ struct ReservationDetailDTO: Decodable {
     struct HostDTO: Decodable {
         let hostId: Int
         let nickname: String
-        let profileImageName: String
+        let profileImageCode: String
         
-        init(hostId: Int, nickname: String, profileImageName: String) {
+        init(hostId: Int, nickname: String, profileImageCode: String) {
             self.hostId = hostId
             self.nickname = nickname
-            self.profileImageName = profileImageName
+            self.profileImageCode = profileImageCode
         }
     }
     
@@ -70,7 +70,7 @@ extension ReservationDetailDTO.HostDTO {
         .init(
             hostId: self.hostId,
             nickName: self.nickname,
-            profileImageName: self.profileImageName
+            profileImageCode: self.profileImageCode
         )
     }
 }
@@ -81,7 +81,7 @@ extension ReservationDetailDTO {
             reservationId: self.reservationId,
             title: self.title,
             category: .init(rawValue: self.category) ?? .activity,
-            reservationDatetime: self.reservationDatetime.toDate(with: .iso8601ms),
+            reservationDatetime: self.reservationDatetime.toDate(with: .iso8601),
             description: self.description,
             linkUrl: self.linkUrl,
             images: self.images,
@@ -89,8 +89,8 @@ extension ReservationDetailDTO {
             currentUser: self.currentUser.toDomain,
             participantCount: self.participantCount,
             maxParticipants: self.maxParticipants,
-            createdAt: self.createdAt.toDate(with: .iso8601ms),
-            updatedAt: self.updatedAt.toDate(with: .iso8601ms)
+            createdAt: self.createdAt.toDate(with: .iso8601),
+            updatedAt: self.updatedAt.toDate(with: .iso8601)
         )
     }
 }

--- a/Projects/Data/User/Sources/DTO/GetProfileListDTO.swift
+++ b/Projects/Data/User/Sources/DTO/GetProfileListDTO.swift
@@ -9,15 +9,13 @@ import Foundation
 import UserDomain
 
 struct ProfileDTO: Decodable {
-    let profileImageCodeName: String
-    let imageUrl: String
+    let profileImageCode: String
 }
 
 extension ProfileDTO {
     var toDomain: KokProfile {
         .init(
-            type: ProfileType(rawValue: profileImageCodeName) ?? .blue,
-            imageUrl: imageUrl
+            type: ProfileType(rawValue: profileImageCode) ?? .blue
         )
     }
 }

--- a/Projects/Domain/Reservation/Sources/Entity/ReservationDetail.swift
+++ b/Projects/Domain/Reservation/Sources/Entity/ReservationDetail.swift
@@ -55,12 +55,12 @@ public struct ReservationDetail: Equatable {
     public struct Host: Equatable {
         public let hostId: Int
         public let nickName: String
-        public let profileImageName: String
+        public let profileImageCode: String
         
-        public init(hostId: Int, nickName: String, profileImageName: String) {
+        public init(hostId: Int, nickName: String, profileImageCode: String) {
             self.hostId = hostId
             self.nickName = nickName
-            self.profileImageName = profileImageName
+            self.profileImageCode = profileImageCode
         }
     }
     
@@ -94,7 +94,7 @@ public extension ReservationDetail {
         host: .init(
             hostId: -1,
             nickName: "예약자",
-            profileImageName: "IMG_001"
+            profileImageCode: "PURPLE"
         ),
         currentUser: .init(
             userId: -1,

--- a/Projects/Domain/User/Sources/Entity/ProfileEntity.swift
+++ b/Projects/Domain/User/Sources/Entity/ProfileEntity.swift
@@ -10,10 +10,8 @@ import Foundation
 public struct KokProfile: Identifiable {
     public var id: String { type.rawValue }
     public let type: ProfileType
-    public let imageUrl: String
     
-    public init(type: ProfileType, imageUrl: String) {
+    public init(type: ProfileType) {
         self.type = type
-        self.imageUrl = imageUrl
     }
 }

--- a/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
+++ b/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
@@ -206,7 +206,7 @@ public extension ReservationDetail {
         host: .init(
             hostId: -1,
             nickName: "예약자",
-            profileImageName: "IMG_001"
+            profileImageCode: "PURPLE"
         ),
         currentUser: .init(
             userId: -1,

--- a/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationView.swift
+++ b/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationView.swift
@@ -185,7 +185,14 @@ struct ShareReservationView: View {
                 icon: .link,
                 title: "링크",
                 content: viewModel.reservation.linkUrl
-            )
+            ) {
+                guard let url = URL(string: viewModel.reservation.linkUrl),
+                      UIApplication.shared.canOpenURL(url) else {
+                    viewModel.reduce(.showInvalidLinkToast)
+                    return
+                }
+                UIApplication.shared.open(url)
+            }
             HGDividerView().padding(.vertical, 12)
             cardDetailHeader(
                 icon: .camera,
@@ -283,6 +290,7 @@ struct ShareReservationView: View {
         icon: HGIcons,
         title: String,
         content: String?,
+        onTapContent: (()->Void)? = nil,
         boldContent: String? = nil
     ) -> some View {
         HStack(spacing: 2) {
@@ -300,6 +308,9 @@ struct ShareReservationView: View {
                     .foregroundStyle(.gray95)
                     .lineLimit(1)
                     .frame(maxWidth: 150, alignment: .trailing)
+                    .onTapGesture {
+                        onTapContent?()
+                    }
             }
             
             if let boldContent {

--- a/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationView.swift
+++ b/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationView.swift
@@ -96,18 +96,18 @@ struct ShareReservationView: View {
     private var cardFrontView: some View {
         VStack(spacing: .zero) {
             HStack(spacing: 4) {
-                LazyImage(url: .init(string: viewModel.reservation.host.profileImageName)) { state in
-                    if let image = state.image {
-                        image
-                            .resizable()
-                            .scaledToFit()
-                            .frame(24)
-                    } else {
-                        HGColors.opacityBlack10.color
-                            .frame(24)
-                    }
+                if let hostProfile = viewModel.hostProfile {
+                    hostProfile.image
+                        .resizable()
+                        .scaledToFit()
+                        .frame(24)
+                        .clipShape(.circle)
+                } else {
+                    HGColors.opacityBlack10.color
+                        .frame(24)
+                        .clipShape(.circle)
                 }
-                .clipShape(.circle)
+                
                 Text(viewModel.reservation.host.nickName)
                     .setTypo(.body_14_bold)
                     .foregroundStyle(.white)

--- a/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationViewModel.swift
+++ b/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationViewModel.swift
@@ -68,6 +68,7 @@ final class ShareReservationViewModel: Reducerable {
         case toggleCardState
         case didTapBottomButton
         case didTapDismiss(dismiss: ()->Void)
+        case showInvalidLinkToast
     }
     
     func reduce(_ action: Action) {
@@ -112,6 +113,10 @@ final class ShareReservationViewModel: Reducerable {
                         self.state.isLoading = false
                     }
                 }
+            }
+        case .showInvalidLinkToast:
+            Task { @MainActor in
+                ToastUtils.showToast("유효하지 않은 링크입니다!")
             }
             
         case .toggleCardState:

--- a/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationViewModel.swift
+++ b/Projects/Features/Reservation/Sources/ShareReservation/ShareReservationViewModel.swift
@@ -13,6 +13,7 @@ import ReservationDomain
 import ReservationFeatureInterface
 import HGDesignSystem
 import SwiftUI
+import UserDomain
 import Nuke
 
 @Observable
@@ -23,6 +24,7 @@ final class ShareReservationViewModel: Reducerable {
     
     /// 예약장을 받는 사람 보내는 사람의 액션을 구분하기 위함
     let shareViewType: ShareViewType
+    var hostProfile: ProfileType?
     let reservationId: Int
     
     @ObservationIgnored
@@ -100,6 +102,7 @@ final class ShareReservationViewModel: Reducerable {
                     }
                     
                     await MainActor.run {
+                        self.hostProfile = ProfileType(rawValue: reservationDetail.host.profileImageCode)
                         self.state.isLoading = false
                         self.state.reservation = reservationDetail
                     }

--- a/Tuist/ProjectDescriptionHelpers/Settings+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings+Extension.swift
@@ -12,7 +12,8 @@ public extension Settings {
         base: [
             "DEVELOPMENT_TEAM": "V2YNV9QV27",
             "CODE_SIGN_STYLE": "Manual",
-            "PROVISIONING_PROFILE_SPECIFIER": "match Development HGDGDS.HGDGDS-iOS"
+            "PROVISIONING_PROFILE_SPECIFIER": "match Development HGDGDS.HGDGDS-iOS",
+            "OTHER_LDFLAGS": ["-all_load -Objc"]
         ],
         configurations: [
             .debug(


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #97 


##  📝 작업 내용
- ### ReservationDetail, ReservationDetailDTO 수정
- ### iso8601ms -> iso8601 포맷터 수정
- ### 예약 공유 화면에서 호스트 유저 프로필이미지 로컬에서 컨트롤

<!--
## 📸 작업 스크린샷 (Optional)
- 참고하기 좋은 이미지가 있다면 첨부해주세요
- ex) 작업하는 Figma 화면, 에러로그 등

<img src="https://github.com/namsoo5.png" width="300" height="400"/>

|제목1|제목2|
|:---:|:---:|
|이미지1|이미지2|
-->
  

## 📣 그 외 알릴 내용
허거덩 화이탱


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 호스트 프로필 이미지를 코드 값(`profileImageCode`) 기반으로 표시하도록 개선되었습니다.
  * 호스트 프로필 이미지 유형(`hostProfile`)이 추가되어, 프로필 이미지를 보다 유연하게 처리할 수 있습니다.
  * 공유 예약 화면에서 링크 텍스트를 탭하면 유효한 URL을 열고, 유효하지 않은 경우 토스트 메시지가 표시됩니다.

* **버그 수정**
  * 날짜 파싱 형식이 ISO 8601 표준(밀리초 제외)으로 변경되어, 일부 날짜 처리의 정확도가 개선되었습니다.

* **리팩터**
  * 호스트 프로필 이미지 관련 속성명이 `profileImageName`에서 `profileImageCode`로 변경되었습니다.
  * 사용자 프로필 관련 데이터 모델에서 이미지 URL 속성이 제거되고, 프로필 코드명만 사용하도록 단순화되었습니다.

* **기타**
  * 빌드 설정에 새로운 링커 플래그(`-all_load -Objc`)가 추가되어 빌드 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->