### PR TITLE
1.0.0(6) QA 및 UX개선

### DIFF
--- a/Projects/Features/CreateReservation/Sources/CreateReservationView.swift
+++ b/Projects/Features/CreateReservation/Sources/CreateReservationView.swift
@@ -208,6 +208,7 @@ struct CreateReservationView: View {
                 required: true
             )
             .disabled(true)
+            .contentShape(.rect)
             .onTapGesture {
                 viewModel.reduce(.didTapDatePicker)
             }
@@ -222,6 +223,7 @@ struct CreateReservationView: View {
                 required: true
             )
             .disabled(true)
+            .contentShape(.rect)
             .onTapGesture {
                 viewModel.reduce(.didTapTimePicker)
             }

--- a/Projects/Features/CreateReservation/Sources/CreateReservationViewModel.swift
+++ b/Projects/Features/CreateReservation/Sources/CreateReservationViewModel.swift
@@ -89,8 +89,10 @@ final class CreateReservationViewModel: Reducerable {
             }
         case .didTapDatePicker:
             state.showDatePicker = true
+            state.selectedDate = Date.now
         case .didTapTimePicker:
             state.showTimePicker = true
+            state.selectedTime = Date.now
         case let .didSelectDate(date):
             state.selectedDate = date
         case let .didSelectTime(date):

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageViewModel.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageViewModel.swift
@@ -42,6 +42,7 @@ final class MyPageViewModel: Reducerable {
     @MainActor
     func requestUserInfo() async {
         do {
+            await userManager.requestUserInfo()
             let userInfo = try await userManager.fetchUser()
             self.state.nickname = userInfo.nickname
             self.state.profileType = userInfo.profileType

--- a/Projects/Features/MyPage/Sources/Setting/SettingView.swift
+++ b/Projects/Features/MyPage/Sources/Setting/SettingView.swift
@@ -35,9 +35,6 @@ struct SettingView: View {
             Text(viewModel.nickname)
                 .setTypo(.title_20_bold)
                 .foregroundStyle(.gray100Black)
-                .onLongPressGesture(minimumDuration: 3) {
-                    viewModel.reduce(.resetKeychain)
-                }
             Spacer()
             HGButton(title: "프로필 편집", size: .xSmall, variant: .subtle, isMaxWidth: false) {
                 coordinator.push(.editProfile)
@@ -92,6 +89,9 @@ struct SettingView: View {
                 Text(viewModel.versionString)
                     .setTypo(.body_16_medium)
                     .foregroundStyle(.gray50)
+                    .onLongPressGesture(minimumDuration: 3) {
+                        viewModel.reduce(.resetKeychain)
+                    }
             }
         }
     }

--- a/Projects/Features/Reservation/Sources/Reservation/ReservationView.swift
+++ b/Projects/Features/Reservation/Sources/Reservation/ReservationView.swift
@@ -361,16 +361,12 @@ struct ReservationView: View {
                     Text(member.nickname)
                         .setTypo(.body_16_bold)
                         .foregroundStyle(.gray95)
-                    Button {
+                    HGButton(
+                        title: "콕 찌르기",
+                        size: .small,
+                        isMaxWidth: true
+                    ) {
                         viewModel.reduce(.kokButtonTapped(member.userId))
-                    } label: {
-                        Text("콕 찌르기")
-                            .setTypo(.body_14_bold)
-                            .foregroundStyle(.gray0White)
-                            .frame(height: 31)
-                            .frame(maxWidth: .infinity)
-                            .background(.orange500Main)
-                            .clipShape(Capsule())
                     }
                 }
                 .padding(.top, 15)

--- a/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
+++ b/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
@@ -138,9 +138,9 @@ final class ReservationViewModel: Reducerable {
     
     @MainActor
     private func kok(reservationId: Int, userId: Int) async {
+        ToastUtils.showToast("친구를 콕 찔러 알림을 보냈어요", icon: .checkInCircle)
         do {
             try await reservationUseCase.kok(reservationId: reservationId, userId: userId)
-            ToastUtils.showToast("친구를 콕 찔러 알림을 보냈어요", icon: .checkInCircle)
         } catch {
             LoggerUtil.log("콕찌르기 실패: \(error)", level: .error)
         }

--- a/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputView.swift
+++ b/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputView.swift
@@ -174,6 +174,7 @@ struct ReservationResultInputView: View {
                 required: true
             )
             .disabled(true)
+            .contentShape(.rect)
             .onTapGesture {
                 viewModel.reduce(.didTapReservationDateButton)
             }
@@ -187,6 +188,7 @@ struct ReservationResultInputView: View {
                 hiddenClearButton: true
             )
             .disabled(true)
+            .contentShape(.rect)
             .onTapGesture {
                 viewModel.reduce(.didTapReservationHourButton)
             }

--- a/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputViewModel.swift
+++ b/Projects/Features/ReservationHistory/Sources/ReservationResultInput/ReservationResultInputViewModel.swift
@@ -69,8 +69,14 @@ final class ReservationResultInputViewModel: Reducerable {
             checkValidationDoneButton()
         case .didTapReservationDateButton:
             state.isPresentedDatePicker = true
+            let now = Date.now
+            state.successReservationDate = now
+            state.successReservationDateString = now.formatted(with: .yyyyMMddEEKorean)
         case .didTapReservationHourButton:
             state.isPresentedHourPicker = true
+            let now = Date.now
+            state.successReservationTime = now
+            state.successReservationTimeString = now.formatted(with: .ahhmmKorean)
         case let .didChangeDate(date):
             state.successReservationDate = date
             state.successReservationDateString = date.formatted(with: .yyyyMMddEEKorean)

--- a/Tuist/ProjectDescriptionHelpers/Constants.swift
+++ b/Tuist/ProjectDescriptionHelpers/Constants.swift
@@ -12,6 +12,6 @@ public enum Constants {
     public static let projectName = "HGDGDS"
     public static let targetVersion = "18.0"
     public static let projectBasePath: String = "Projects/"
-    public static let buildNumber: String = "6"
+    public static let buildNumber: String = "8"
     public static let version: String = "1.0.0"
 }


### PR DESCRIPTION
##  📝 작업 내용
- 콕찌르기 버튼 디자인컴포넌트로 변경
- 데이터피커 터치영역수정
- 데이터피커 터치시 기본값 매핑
- 마이페이지 정보 리프레쉬로직추가
- 토큰초기화 위치변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능 및 개선**
  * 예약 생성 및 예약 결과 입력 화면에서 비활성화된 날짜/시간 입력란의 터치 영역이 확대되어 더 쉽게 선택할 수 있습니다.
  * 예약 생성 및 예약 결과 입력 시 날짜/시간 버튼을 누르면 현재 시각으로 자동 초기화됩니다.
  * 예약 화면에서 "콕 찌르기" 버튼이 일관된 디자인(HGButton)으로 개선되었습니다.
  * "콕 찌르기" 알림 토스트가 버튼을 누르자마자 바로 표시됩니다.

* **버그 수정 및 기타**
  * 마이페이지에서 사용자 정보 요청이 더욱 신뢰성 있게 동작하도록 개선되었습니다.
  * 프로필 닉네임에서의 롱프레스 제스처가 고객센터 버전 정보로 이동되었습니다.
  * 앱 빌드 번호가 8로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->