### PR TITLE
[#98] Feat: 예약 상세 화면 진입 시 준비완료 상태 반영

### DIFF
--- a/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
+++ b/Projects/Features/Reservation/Sources/Reservation/ReservationViewModel.swift
@@ -121,6 +121,7 @@ final class ReservationViewModel: Reducerable {
             let members = try await reservationUseCase.getReservationMembers(id: reservationId)
             state.members = members.members
             state.me = members.me
+            state.isReady = members.me.status == .ready
         } catch {
             LoggerUtil.log("예약 멤버 가져오기 실패: \(error)", level: .error)
         }


### PR DESCRIPTION
## 🔗 연결된 이슈 번호
- #98 


##  📝 작업 내용
- 예약 상세 화면 진입 시 준비완료 상태 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예약 멤버 정보를 불러온 후, 멤버의 준비 상태에 따라 화면의 준비 상태 표시가 올바르게 동기화되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->